### PR TITLE
Fix nested messages

### DIFF
--- a/protoc_docs/parser.py
+++ b/protoc_docs/parser.py
@@ -167,7 +167,6 @@ class CodeGeneratorParser(object):
             return
 
         # If applicable, create the MessageStructure object for this.
-        # import pdb ; pdb.set_trace()
         if not message_structure:
             message_structure = MessageStructure.get_or_create(
                 name='{pkg}.{name}'.format(

--- a/protoc_docs/parser.py
+++ b/protoc_docs/parser.py
@@ -167,6 +167,7 @@ class CodeGeneratorParser(object):
             return
 
         # If applicable, create the MessageStructure object for this.
+        # import pdb ; pdb.set_trace()
         if not message_structure:
             message_structure = MessageStructure.get_or_create(
                 name='{pkg}.{name}'.format(
@@ -178,6 +179,18 @@ class CodeGeneratorParser(object):
         # If the length of the path is 2 or greater, call this method
         # recursively.
         if len(path) >= 2:
+            # Nested types are possible.
+            #
+            # In this case, we need to ensure that we do not lose
+            # the outer layers of the nested type name; otherwise the
+            # insertion point name will be wrong.
+            if not message_structure.name.endswith(child.name):
+                message_structure = MessageStructure.get_or_create(
+                    name='{parent}.{child}'.format(
+                        child=child.name,
+                        parent=message_structure.name,
+                    ),
+                )
             return self.parse_path(child, path, docstring, message_structure)
 
         # Write the documentation to the appropriate spot.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -50,7 +50,32 @@ class TestCodeGeneratorParser(unittest.TestCase):
 
         # Make incredibly basic assertions about the collected data.
         assert len(answer) == 1
-        assert len(answer['protos/descriptor.proto']) == 24
+        assert {i.name for i in answer['protos/descriptor.proto']} == {
+            'google.protobuf.FileDescriptorSet',
+            'google.protobuf.FieldOptions',
+            'google.protobuf.FileOptions',
+            'google.protobuf.MessageOptions',
+            'google.protobuf.FileDescriptorProto',
+            'google.protobuf.FieldDescriptorProto',
+            'google.protobuf.ServiceOptions',
+            'google.protobuf.MethodDescriptorProto',
+            'google.protobuf.EnumDescriptorProto',
+            'google.protobuf.EnumValueDescriptorProto',
+            'google.protobuf.UninterpretedOption.NamePart',
+            'google.protobuf.SourceCodeInfo',
+            'google.protobuf.SourceCodeInfo.Location',
+            'google.protobuf.GeneratedCodeInfo.Annotation',
+            'google.protobuf.MethodOptions',
+            'google.protobuf.DescriptorProto',
+            'google.protobuf.GeneratedCodeInfo',
+            'google.protobuf.EnumValueOptions',
+            'google.protobuf.UninterpretedOption',
+            'google.protobuf.ServiceDescriptorProto',
+            'google.protobuf.OneofOptions',
+            'google.protobuf.DescriptorProto.ReservedRange',
+            'google.protobuf.OneofDescriptorProto',
+            'google.protobuf.EnumOptions',
+        }
 
     def test_find_docs_no_output_files(self):
         # Read the file, but this time wipe out the list of target output

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -50,7 +50,7 @@ class TestCodeGeneratorParser(unittest.TestCase):
 
         # Make incredibly basic assertions about the collected data.
         assert len(answer) == 1
-        assert len(answer['protos/descriptor.proto']) == 22
+        assert len(answer['protos/descriptor.proto']) == 24
 
     def test_find_docs_no_output_files(self):
         # Read the file, but this time wipe out the list of target output

--- a/tests/test_py_docstring.py
+++ b/tests/test_py_docstring.py
@@ -58,4 +58,4 @@ class PyDocstringTests(unittest.TestCase):
 
         # Just ensure that the bytestream is the appropriate length.
         # This is a terrible test. :-/
-        assert len(output_file.getvalue()) == 25043
+        assert len(output_file.getvalue()) == 25294


### PR DESCRIPTION
This bugfix solves an issue where certain nested messages were output using the wrong insertion point, causing protoc compilation to fail.