### PR TITLE
encode docstring with utf-8

### DIFF
--- a/protoc_docs/code.py
+++ b/protoc_docs/code.py
@@ -103,4 +103,4 @@ class MessageStructure(object):
             answer += '    %s:\n%s\n' %  (k, '\n'.join(tw.wrap(v)))
 
         # Done.
-        return answer
+        return answer.encode('utf-8')


### PR DESCRIPTION
I ran into this error running the plugin:

```
protoc -I. --python_out=$TARGET --pydocstring_out=$TARGET  google/iam/v1/*.proto
Traceback (most recent call last):
  File "/usr/local/google/home/ndietz/Documents/go/src/github.com/googleapis/googleapis/venv/bin/protoc-gen-pydocstring", line 10, in <module>
    sys.exit(main())
  File "/usr/local/google/home/ndietz/Documents/go/src/github.com/googleapis/googleapis/venv/local/lib/python2.7/site-packages/protoc_docs/bin/py_docstring.py", line 54, in main
    docstring=struct.get_python_docstring(),
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2018' in position 371: ordinal not in range(128)
--pydocstring_out: protoc-gen-pydocstring: Plugin failed with status code 1.
```

The diff here is what I used locally to fix it. Just returns a `utf-8` encoded string instead.

* libprotoc 3.6.1
* https://github.com/googleapis/googleapis/commit/b4c73face84fefb967ef6c72f0eae64faf67895f
* v0.3.0 of this tool
