### PR TITLE
change doc from dict to object syntax

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ jobs:
           command: pip install --upgrade nox-automation codecov
       - run:
           name: Run unit tests.
-          command: nox -e "unit_tests(python_version='2.7')"
+          command: nox --noxfile nox.py -e "unit_tests(python_version='2.7')"
     working_directory: /usr/src/protoc_docs_plugin/
 
   unit-python3.4:
@@ -39,7 +39,7 @@ jobs:
           command: pip install --upgrade nox-automation codecov
       - run:
           name: Run unit tests.
-          command: nox -e "unit_tests(python_version='3.4')"
+          command: nox --noxfile nox.py -e "unit_tests(python_version='3.4')"
     working_directory: /usr/src/protoc_docs_plugin/
 
   unit-python3.5:
@@ -55,7 +55,7 @@ jobs:
           command: pip install --upgrade nox-automation codecov
       - run:
           name: Run unit tests.
-          command: nox -e "unit_tests(python_version='3.5')"
+          command: nox --noxfile nox.py -e "unit_tests(python_version='3.5')"
     working_directory: /usr/src/protoc_docs_plugin/
 
   unit-python3.6:
@@ -71,7 +71,7 @@ jobs:
           command: pip install --upgrade nox-automation codecov
       - run:
           name: Run unit tests.
-          command: nox -e "unit_tests(python_version='3.6')"
+          command: nox --noxfile nox.py -e "unit_tests(python_version='3.6')"
     working_directory: /usr/src/protoc_docs_plugin/
 
 

--- a/nox.py
+++ b/nox.py
@@ -22,7 +22,7 @@ import nox
 def unit_tests(session, python_version):
     """Run the unit tests."""
 
-    session.venv.interpreter = 'python%s' % python_version
+    session.virtualenv.interpreter = 'python%s' % python_version
     session.install('mock', 'pytest', 'pytest-cov')
     session.install('-e', '.')
     session.run('pytest', '--cov=protoc_docs')

--- a/nox.py
+++ b/nox.py
@@ -22,7 +22,7 @@ import nox
 def unit_tests(session, python_version):
     """Run the unit tests."""
 
-    session.interpreter = 'python%s' % python_version
+    session.venv.interpreter = 'python%s' % python_version
     session.install('mock', 'pytest', 'pytest-cov')
     session.install('-e', '.')
     session.run('pytest', '--cov=protoc_docs')

--- a/protoc_docs/bin/py_docstring.py
+++ b/protoc_docs/bin/py_docstring.py
@@ -50,7 +50,7 @@ def main(input_file=sys.stdin, output_file=sys.stdout):
 
                 # Seriously, protoc, an insertion point but no trailing
                 # comma before it?
-                content=',\n__doc__ = """{docstring}""",'.format(
+                content=',\n\'__doc__\' : """{docstring}""",'.format(
                     docstring=struct.get_python_docstring(),
                 ),
             ))

--- a/tests/test_py_docstring.py
+++ b/tests/test_py_docstring.py
@@ -58,7 +58,7 @@ class PyDocstringTests(unittest.TestCase):
 
         # Just ensure that the bytestream is the appropriate length.
         # This is a terrible test. :-/
-        assert len(output_file.getvalue()) == 25318
+        assert len(output_file.getvalue()) == 25366
 
     def test_init_files(self):
         files = ['foo.proto', '/bar.proto', 'baz/qux/corge.proto']


### PR DESCRIPTION
The generated files from python_out are using a object notation instead of dict. These are syntactically different and breaks when interpreted. 