### PR TITLE
Dict construction via kword param, not via literal

### DIFF
--- a/protoc_docs/bin/py_docstring.py
+++ b/protoc_docs/bin/py_docstring.py
@@ -64,7 +64,7 @@ def main(input_file=sys.stdin, output_file=sys.stdout):
         answer.append(CodeGeneratorResponse.File(
             name=fn.replace('.proto', '_pb2.py'),
             insertion_point='class_scope:%s' % struct.name,
-            content=',\n\'__doc__\': """{docstring}""",'.format(
+            content='\n__doc__ = """{docstring}""",'.format(
                 docstring=struct.get_python_docstring(meta_docstrings[index]),
             ),
         ))


### PR DESCRIPTION
Attempted fix for https://github.com/googleapis/gapic-generator/issues/3073