### PR TITLE
Add trailing comma to line before `__doc__`

### DIFF
--- a/protoc_docs/bin/py_docstring.py
+++ b/protoc_docs/bin/py_docstring.py
@@ -64,7 +64,7 @@ def main(input_file=sys.stdin, output_file=sys.stdout):
         answer.append(CodeGeneratorResponse.File(
             name=fn.replace('.proto', '_pb2.py'),
             insertion_point='class_scope:%s' % struct.name,
-            content='\n__doc__ = """{docstring}""",'.format(
+            content=',\n__doc__ = """{docstring}""",'.format(
                 docstring=struct.get_python_docstring(meta_docstrings[index]),
             ),
         ))


### PR DESCRIPTION
Generated libs are missing the comma on the `__module__` line before `__doc__`

```py
Schema = _reflection.GeneratedProtocolMessageType('Schema', (_message.Message,), dict(
  DESCRIPTOR = _SCHEMA,
  __module__ = 'google.cloud.datacatalog_v1beta1.proto.schema_pb2'
  
  __doc__ = """Represents a schema (e.g. BigQuery, GoogleSQL, Avro
  schema).
  
  
  Attributes:
      columns:
          Required. Schema of columns. A maximum of 10,000 columns and
          sub-columns can be specified.
  """,
  # @@protoc_insertion_point(class_scope:google.cloud.datacatalog.v1beta1.Schema)
  ))
_sym_db.RegisterMessage(Schema)
```

