### PR TITLE
fix two minor problems

### DIFF
--- a/protoc_docs/parser.py
+++ b/protoc_docs/parser.py
@@ -178,12 +178,15 @@ class CodeGeneratorParser(object):
 
         # If applicable, create the MessageStructure object for this.
         if not message_structure:
-            message_structure = MessageStructure.get_or_create(
-                name='{pkg}.{name}'.format(
+            if struct.package:
+                name = '{pkg}.{name}'.format(
                     name=child.name,
                     pkg=struct.package,
-                ),
-            )
+                )
+            else: 
+                name = child.name
+            message_structure = MessageStructure.get_or_create(name)
+
 
         # If the length of the path is 2 or greater, call this method
         # recursively.
@@ -208,6 +211,8 @@ class CodeGeneratorParser(object):
         # documentation.
         if message_structure.name.endswith(child.name):
             message_structure.docstring = docstring
+        elif child.DESCRIPTOR.name in ("OneofDescriptorProto", "FieldDescriptorProto"):
+            message_structure.members[child.name] = docstring
         elif self._is_mixed_case(child.name):
             message_structure = MessageStructure.get_or_create(
                 name='{parent}.{name}'.format(


### PR DESCRIPTION
Hi,
I created this PR mainly so I could show an error I get while trying to use this plugin.
the first problem is that files without packages are not handled correctly.
the suggested fix is in line 181.
the other problem is that mixed case fields are not necessarily sub messages...
why is the logic not checking the actual descriptor type?

This PR is lacking in tests - sorry, the tests work with an already compiled proto which i'm not sure how to get a hold on...

Thanks!

```proto
syntax = "proto3";

message Example1 {
    oneof Target { // some comment 
        string key = 3;
    }
}
```

```proto
syntax = "proto2";

message Example2 {
    optional uint32 someName=3; // some comment
}

```
