### PR TITLE
fix: support proto3 optional fields

### DIFF
--- a/protoc_docs/bin/py_docstring.py
+++ b/protoc_docs/bin/py_docstring.py
@@ -76,6 +76,7 @@ def main(input_file=sys.stdin, output_file=sys.stdout):
             content='',
         ))
     cgr = CodeGeneratorResponse(file=answer)
+    cgr.supported_features = CodeGeneratorResponse.FEATURE_PROTO3_OPTIONAL
     output_file.write(cgr.SerializeToString())
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setuptools.setup(
     url='https://github.com/googleapis/protoc-docs-plugin',
     license='Apache-2.0',
     install_requires=(
-        'protobuf >= 3.3.0',
+        'protobuf >= 3.12.2',
         'pypandoc >= 1.4',
     ),
     packages=setuptools.find_packages(),


### PR DESCRIPTION
Adding support for proto3 `optional` fields. Basically, the plugin should just notify `protoc` that it supports it, no other changes are needed.

It's very possible that this change will break some tests, @busunkim96 if this is the case, I'll talk to you next week :)
